### PR TITLE
feat: add support for Copilot CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,3 @@ Thumbs.db
 
 # Misc
 .gocache
-ai-sessions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
       - id: gofmt
         name: gofmt
-        entry: bash -lc 'if [ "$#" -gt 0 ]; then files=$(gofmt -l "$@" || true); if [ -n "$files" ]; then echo "Files need formatting:"; echo "$files"; gofmt -w "$@"; fi; fi'
+        entry: bash -lc 'if [ "$#" -gt 0 ]; then files=$(gofmt -l "$@" || true); if [ -n "$files" ]; then echo "Files need formatting:"; echo "$files"; gofmt -w "$@" && git add "$@"; fi; fi'
         language: system
         types: [go]
       - id: go-vet

--- a/adapters/claude.go
+++ b/adapters/claude.go
@@ -231,7 +231,7 @@ func (c *ClaudeAdapter) parseSessionMetadata(filePath, projectPath string) (Sess
 			}
 
 			// Extract the text and check if it's a system message to skip
-			firstLine := extractFirstLine(content)
+			firstLine := extractFirstLineFromClaudeContent(content)
 			trimmed := strings.TrimSpace(firstLine)
 
 			// Skip empty messages
@@ -318,9 +318,9 @@ func stripSystemXMLTags(text string) string {
 	return text
 }
 
-// extractFirstLine extracts the first non-empty line from content.
-// Content can be a string or a structured object.
-func extractFirstLine(content interface{}) string {
+// extractFirstLineFromClaudeContent extracts the first non-empty line from Claude content.
+// It handles various content types (string, structured blocks, etc.) and strips system XML tags.
+func extractFirstLineFromClaudeContent(content interface{}) string {
 	switch v := content.(type) {
 	case string:
 		lines := strings.Split(v, "\n")
@@ -348,13 +348,13 @@ func extractFirstLine(content interface{}) string {
 		for _, item := range v {
 			if m, ok := item.(map[string]interface{}); ok {
 				if text, ok := m["text"].(string); ok {
-					return extractFirstLine(text)
+					return extractFirstLineFromClaudeContent(text)
 				}
 			}
 		}
 	case map[string]interface{}:
 		if text, ok := v["text"].(string); ok {
-			return extractFirstLine(text)
+			return extractFirstLineFromClaudeContent(text)
 		}
 	}
 	return ""

--- a/adapters/copilot.go
+++ b/adapters/copilot.go
@@ -419,42 +419,163 @@ func (c *CopilotAdapter) readAllMessages(filePath string) ([]Message, error) {
 }
 
 // SearchSessions searches Copilot CLI sessions for the given query.
+// It reads each file only once to avoid redundant I/O.
 func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([]Session, error) {
-	// First, list all sessions
-	sessions, err := c.ListSessions(projectPath, 0)
+	sessionsDir := filepath.Join(c.homeDir, ".copilot", "session-state")
+
+	if _, err := os.Stat(sessionsDir); os.IsNotExist(err) {
+		return []Session{}, nil
+	}
+
+	if projectPath != "" {
+		var err error
+		projectPath, err = filepath.Abs(projectPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path: %w", err)
+		}
+	}
+
+	files, err := filepath.Glob(filepath.Join(sessionsDir, "*.jsonl"))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list session files: %w", err)
 	}
 
 	query = strings.ToLower(query)
 	var matches []Session
 
-	// Search through each session
-	for _, session := range sessions {
-		// Check if query is in first message
-		if strings.Contains(strings.ToLower(session.FirstMessage), query) {
-			matches = append(matches, session)
-			continue
-		}
-
-		// Search through full session content
-		messages, err := c.readAllMessages(session.FilePath)
+	// Read each file once and search in a single pass
+	for _, filePath := range files {
+		session, contents, err := c.parseSessionWithContents(filePath)
 		if err != nil {
 			continue
 		}
 
-		for _, msg := range messages {
-			if strings.Contains(strings.ToLower(msg.Content), query) {
-				matches = append(matches, session)
+		// Filter by project path if specified
+		if projectPath != "" && session.ProjectPath != projectPath {
+			continue
+		}
+
+		// Search in all message content
+		found := false
+		for _, content := range contents {
+			if strings.Contains(strings.ToLower(content), query) {
+				found = true
 				break
 			}
 		}
 
-		// Apply limit if we've found enough
-		if limit > 0 && len(matches) >= limit {
-			break
+		if found {
+			matches = append(matches, session)
+			if limit > 0 && len(matches) >= limit {
+				break
+			}
 		}
 	}
 
+	// Sort by timestamp (newest first)
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Timestamp.After(matches[j].Timestamp)
+	})
+
 	return matches, nil
+}
+
+// parseSessionWithContents reads a session file and returns metadata plus all message contents.
+// This avoids reading the file twice when both are needed for searching.
+func (c *CopilotAdapter) parseSessionWithContents(filePath string) (Session, []string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return Session{}, nil, fmt.Errorf("failed to open session file: %w", err)
+	}
+	defer file.Close()
+
+	session := Session{
+		Source:   "copilot",
+		FilePath: filePath,
+	}
+
+	folderTrustRegex := regexp.MustCompile(`Folder (.+) has been added to trusted folders`)
+	var seenFilePaths []string
+	var contents []string
+	userCount := 0
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		var event copilotEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "session.start":
+			var data copilotSessionStart
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				session.ID = data.SessionID
+				if ts, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
+					session.Timestamp = ts
+				} else if ts, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
+					session.Timestamp = ts
+				}
+			}
+
+		case "session.info":
+			var data copilotSessionInfo
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				if data.InfoType == "folder_trust" {
+					if matches := folderTrustRegex.FindStringSubmatch(data.Message); len(matches) > 1 {
+						session.ProjectPath = matches[1]
+					}
+				}
+			}
+
+		case "user.message":
+			var data copilotUserMessage
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				userCount++
+				contents = append(contents, data.Content)
+				if session.FirstMessage == "" {
+					session.FirstMessage = extractFirstLine(data.Content)
+				}
+			}
+
+		case "assistant.message":
+			var data copilotAssistantMessage
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				contents = append(contents, data.Content)
+			}
+
+		case "tool.execution_start":
+			var data copilotToolExecution
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				var args map[string]interface{}
+				if err := json.Unmarshal(data.Arguments, &args); err == nil {
+					if path, ok := args["path"].(string); ok && strings.HasPrefix(path, "/") {
+						seenFilePaths = append(seenFilePaths, path)
+					}
+				}
+			}
+		}
+	}
+
+	session.UserMessageCount = userCount
+
+	if session.ProjectPath == "" && len(seenFilePaths) > 0 {
+		session.ProjectPath = findCommonDirectory(seenFilePaths)
+	}
+
+	if session.Timestamp.IsZero() {
+		if stat, err := os.Stat(filePath); err == nil {
+			session.Timestamp = stat.ModTime()
+		}
+	}
+
+	if session.ID == "" {
+		base := filepath.Base(filePath)
+		session.ID = strings.TrimSuffix(base, ".jsonl")
+	}
+
+	return session, contents, nil
 }

--- a/adapters/copilot.go
+++ b/adapters/copilot.go
@@ -1,0 +1,457 @@
+package adapters
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// CopilotAdapter implements SessionAdapter for GitHub Copilot CLI sessions.
+// Copilot CLI stores sessions as JSONL files in ~/.copilot/session-state/
+type CopilotAdapter struct {
+	homeDir string
+}
+
+// NewCopilotAdapter creates a new GitHub Copilot CLI session adapter.
+func NewCopilotAdapter() (*CopilotAdapter, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return &CopilotAdapter{
+		homeDir: homeDir,
+	}, nil
+}
+
+// Name returns the adapter name.
+func (c *CopilotAdapter) Name() string {
+	return "copilot"
+}
+
+// copilotEvent represents a single event line in a Copilot JSONL session file.
+type copilotEvent struct {
+	Type      string          `json:"type"`
+	Data      json.RawMessage `json:"data"`
+	ID        string          `json:"id"`
+	Timestamp string          `json:"timestamp"`
+	ParentID  *string         `json:"parentId"`
+}
+
+// copilotSessionStart represents the data for a session.start event.
+type copilotSessionStart struct {
+	SessionID      string `json:"sessionId"`
+	Version        int    `json:"version"`
+	Producer       string `json:"producer"`
+	CopilotVersion string `json:"copilotVersion"`
+	StartTime      string `json:"startTime"`
+}
+
+// copilotSessionInfo represents the data for a session.info event.
+type copilotSessionInfo struct {
+	InfoType string `json:"infoType"`
+	Message  string `json:"message"`
+}
+
+// copilotModelChange represents the data for a session.model_change event.
+type copilotModelChange struct {
+	PreviousModel string `json:"previousModel,omitempty"`
+	NewModel      string `json:"newModel"`
+}
+
+// copilotUserMessage represents the data for a user.message event.
+type copilotUserMessage struct {
+	Content     string        `json:"content"`
+	Attachments []interface{} `json:"attachments,omitempty"`
+}
+
+// copilotAssistantMessage represents the data for an assistant.message event.
+type copilotAssistantMessage struct {
+	MessageID    string               `json:"messageId"`
+	Content      string               `json:"content"`
+	ToolRequests []copilotToolRequest `json:"toolRequests,omitempty"`
+}
+
+// copilotToolRequest represents a tool request in an assistant message.
+type copilotToolRequest struct {
+	ToolCallID string          `json:"toolCallId"`
+	Name       string          `json:"name"`
+	Arguments  json.RawMessage `json:"arguments"`
+}
+
+// copilotToolExecution represents the data for tool execution events.
+type copilotToolExecution struct {
+	ToolCallID string          `json:"toolCallId"`
+	ToolName   string          `json:"toolName"`
+	Arguments  json.RawMessage `json:"arguments"`
+	Success    bool            `json:"success,omitempty"`
+	Result     json.RawMessage `json:"result,omitempty"`
+}
+
+// ListSessions returns all Copilot CLI sessions for the given project.
+// If projectPath is empty, returns sessions from ALL projects.
+func (c *CopilotAdapter) ListSessions(projectPath string, limit int) ([]Session, error) {
+	sessionsDir := filepath.Join(c.homeDir, ".copilot", "session-state")
+
+	// Check if directory exists
+	if _, err := os.Stat(sessionsDir); os.IsNotExist(err) {
+		return []Session{}, nil // No sessions
+	}
+
+	// Get absolute path if provided
+	if projectPath != "" {
+		var err error
+		projectPath, err = filepath.Abs(projectPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path: %w", err)
+		}
+	}
+
+	// Read all *.jsonl files
+	files, err := filepath.Glob(filepath.Join(sessionsDir, "*.jsonl"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list session files: %w", err)
+	}
+
+	sessions := make([]Session, 0, len(files))
+	for _, filePath := range files {
+		session, err := c.parseSessionMetadata(filePath)
+		if err != nil {
+			// Skip files we can't parse
+			continue
+		}
+
+		// Filter by project path if specified
+		if projectPath != "" && session.ProjectPath != projectPath {
+			continue
+		}
+
+		sessions = append(sessions, session)
+	}
+
+	// Sort by timestamp (newest first)
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].Timestamp.After(sessions[j].Timestamp)
+	})
+
+	// Apply limit
+	if limit > 0 && len(sessions) > limit {
+		sessions = sessions[:limit]
+	}
+
+	return sessions, nil
+}
+
+// parseSessionMetadata extracts metadata from a Copilot CLI session file.
+func (c *CopilotAdapter) parseSessionMetadata(filePath string) (Session, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return Session{}, fmt.Errorf("failed to open session file: %w", err)
+	}
+	defer file.Close()
+
+	session := Session{
+		Source:   "copilot",
+		FilePath: filePath,
+	}
+
+	// Regex to extract folder path from folder_trust message
+	folderTrustRegex := regexp.MustCompile(`Folder (.+) has been added to trusted folders`)
+
+	// Track file paths seen in tool calls for project path inference
+	var seenFilePaths []string
+	userCount := 0
+
+	scanner := bufio.NewScanner(file)
+	// Increase buffer size for long lines
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		var event copilotEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "session.start":
+			var data copilotSessionStart
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				session.ID = data.SessionID
+				if ts, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
+					session.Timestamp = ts
+				} else if ts, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
+					session.Timestamp = ts
+				}
+			}
+
+		case "session.info":
+			var data copilotSessionInfo
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				if data.InfoType == "folder_trust" {
+					// Extract project path from folder_trust message
+					if matches := folderTrustRegex.FindStringSubmatch(data.Message); len(matches) > 1 {
+						session.ProjectPath = matches[1]
+					}
+				}
+			}
+
+		case "user.message":
+			var data copilotUserMessage
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				userCount++
+				if session.FirstMessage == "" {
+					session.FirstMessage = extractFirstLine(data.Content)
+				}
+			}
+
+		case "tool.execution_start":
+			// Extract file paths from tool arguments for project path inference
+			var data copilotToolExecution
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				var args map[string]interface{}
+				if err := json.Unmarshal(data.Arguments, &args); err == nil {
+					if path, ok := args["path"].(string); ok && strings.HasPrefix(path, "/") {
+						seenFilePaths = append(seenFilePaths, path)
+					}
+				}
+			}
+		}
+	}
+
+	session.UserMessageCount = userCount
+
+	// If we don't have a project path from folder_trust, infer from file paths
+	if session.ProjectPath == "" && len(seenFilePaths) > 0 {
+		session.ProjectPath = findCommonDirectory(seenFilePaths)
+	}
+
+	// If we still don't have a timestamp, use file modification time
+	if session.Timestamp.IsZero() {
+		if stat, err := os.Stat(filePath); err == nil {
+			session.Timestamp = stat.ModTime()
+		}
+	}
+
+	// Extract session ID from filename if not found in content
+	if session.ID == "" {
+		base := filepath.Base(filePath)
+		session.ID = strings.TrimSuffix(base, ".jsonl")
+	}
+
+	return session, nil
+}
+
+// findCommonDirectory finds the longest common directory path from a list of file paths.
+func findCommonDirectory(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	if len(paths) == 1 {
+		return filepath.Dir(paths[0])
+	}
+
+	// Start with the directory of the first path
+	common := filepath.Dir(paths[0])
+
+	for _, p := range paths[1:] {
+		dir := filepath.Dir(p)
+		for !strings.HasPrefix(dir, common) && common != "/" && common != "" {
+			common = filepath.Dir(common)
+		}
+	}
+
+	return common
+}
+
+// GetSession retrieves the full content of a Copilot CLI session with pagination.
+func (c *CopilotAdapter) GetSession(sessionID string, page, pageSize int) ([]Message, error) {
+	sessionsDir := filepath.Join(c.homeDir, ".copilot", "session-state")
+
+	// Try to find the session file directly by ID
+	sessionFile := filepath.Join(sessionsDir, sessionID+".jsonl")
+	if _, err := os.Stat(sessionFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("session not found: %s", sessionID)
+	}
+
+	// Read all messages from the session
+	messages, err := c.readAllMessages(sessionFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply pagination
+	start := page * pageSize
+	if start >= len(messages) {
+		return []Message{}, nil
+	}
+
+	end := start + pageSize
+	if end > len(messages) {
+		end = len(messages)
+	}
+
+	return messages[start:end], nil
+}
+
+// readAllMessages reads all messages from a Copilot CLI session file.
+func (c *CopilotAdapter) readAllMessages(filePath string) ([]Message, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open session file: %w", err)
+	}
+	defer file.Close()
+
+	var messages []Message
+	var currentModel string
+
+	scanner := bufio.NewScanner(file)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	for scanner.Scan() {
+		var event copilotEvent
+		if err := json.Unmarshal(scanner.Bytes(), &event); err != nil {
+			continue
+		}
+
+		var timestamp time.Time
+		if event.Timestamp != "" {
+			if ts, err := time.Parse(time.RFC3339Nano, event.Timestamp); err == nil {
+				timestamp = ts
+			} else if ts, err := time.Parse(time.RFC3339, event.Timestamp); err == nil {
+				timestamp = ts
+			}
+		}
+
+		switch event.Type {
+		case "session.model_change":
+			var data copilotModelChange
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				currentModel = data.NewModel
+			}
+
+		case "user.message":
+			var data copilotUserMessage
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				msg := Message{
+					Role:      "user",
+					Content:   data.Content,
+					Timestamp: timestamp,
+					Metadata:  make(map[string]interface{}),
+				}
+				if currentModel != "" {
+					msg.Metadata["model"] = currentModel
+				}
+				messages = append(messages, msg)
+			}
+
+		case "assistant.message":
+			var data copilotAssistantMessage
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				msg := Message{
+					Role:      "assistant",
+					Content:   data.Content,
+					Timestamp: timestamp,
+					Metadata:  make(map[string]interface{}),
+				}
+				if currentModel != "" {
+					msg.Metadata["model"] = currentModel
+				}
+				// Add tool requests to metadata if present
+				if len(data.ToolRequests) > 0 {
+					toolCalls := make([]map[string]interface{}, len(data.ToolRequests))
+					for i, tr := range data.ToolRequests {
+						var args interface{}
+						json.Unmarshal(tr.Arguments, &args)
+						toolCalls[i] = map[string]interface{}{
+							"id":        tr.ToolCallID,
+							"name":      tr.Name,
+							"arguments": args,
+						}
+					}
+					msg.Metadata["tool_calls"] = toolCalls
+				}
+				messages = append(messages, msg)
+			}
+
+		case "tool.execution_complete":
+			var data copilotToolExecution
+			if err := json.Unmarshal(event.Data, &data); err == nil {
+				var result interface{}
+				json.Unmarshal(data.Result, &result)
+				msg := Message{
+					Role:      "tool",
+					Timestamp: timestamp,
+					Metadata: map[string]interface{}{
+						"tool_call_id": data.ToolCallID,
+						"tool_name":    data.ToolName,
+						"success":      data.Success,
+						"result":       result,
+					},
+				}
+				// Format tool result as content
+				if resultStr, ok := result.(string); ok {
+					msg.Content = resultStr
+				} else if result != nil {
+					if resultBytes, err := json.Marshal(result); err == nil {
+						msg.Content = string(resultBytes)
+					}
+				}
+				messages = append(messages, msg)
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading session file: %w", err)
+	}
+
+	return messages, nil
+}
+
+// SearchSessions searches Copilot CLI sessions for the given query.
+func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([]Session, error) {
+	// First, list all sessions
+	sessions, err := c.ListSessions(projectPath, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	query = strings.ToLower(query)
+	var matches []Session
+
+	// Search through each session
+	for _, session := range sessions {
+		// Check if query is in first message
+		if strings.Contains(strings.ToLower(session.FirstMessage), query) {
+			matches = append(matches, session)
+			continue
+		}
+
+		// Search through full session content
+		messages, err := c.readAllMessages(session.FilePath)
+		if err != nil {
+			continue
+		}
+
+		for _, msg := range messages {
+			if strings.Contains(strings.ToLower(msg.Content), query) {
+				matches = append(matches, session)
+				break
+			}
+		}
+
+		// Apply limit if we've found enough
+		if limit > 0 && len(matches) >= limit {
+			break
+		}
+	}
+
+	return matches, nil
+}

--- a/adapters/copilot.go
+++ b/adapters/copilot.go
@@ -368,7 +368,10 @@ func (c *CopilotAdapter) readAllMessages(filePath string) ([]Message, error) {
 					toolCalls := make([]map[string]interface{}, len(data.ToolRequests))
 					for i, tr := range data.ToolRequests {
 						var args interface{}
-						json.Unmarshal(tr.Arguments, &args)
+						if err := json.Unmarshal(tr.Arguments, &args); err != nil {
+							// Fallback to raw string if unmarshaling fails
+							args = string(tr.Arguments)
+						}
 						toolCalls[i] = map[string]interface{}{
 							"id":        tr.ToolCallID,
 							"name":      tr.Name,

--- a/adapters/helpers_test.go
+++ b/adapters/helpers_test.go
@@ -28,20 +28,20 @@ func TestExtractFirstLineString(t *testing.T) {
 	}
 }
 
-func TestExtractFirstLineStructured(t *testing.T) {
+func TestExtractFirstLineFromClaudeContentStructured(t *testing.T) {
 	content := []interface{}{
 		map[string]interface{}{"text": "First meaningful line\nSecond line"},
 	}
-	got := extractFirstLine(content)
+	got := extractFirstLineFromClaudeContent(content)
 	if got != "First meaningful line" {
-		t.Fatalf("extractFirstLine failed for structured content, got %q", got)
+		t.Fatalf("extractFirstLineFromClaudeContent failed for structured content, got %q", got)
 	}
 }
 
-func TestExtractFirstLineSkipsSystemPrefixes(t *testing.T) {
+func TestExtractFirstLineFromClaudeContentSkipsSystemPrefixes(t *testing.T) {
 	content := "<local-command-stdout>ignored</local-command-stdout>\nReal question?"
-	if got := extractFirstLine(content); got != "Real question?" {
-		t.Fatalf("extractFirstLine failed to skip system block, got %q", got)
+	if got := extractFirstLineFromClaudeContent(content); got != "Real question?" {
+		t.Fatalf("extractFirstLineFromClaudeContent failed to skip system block, got %q", got)
 	}
 }
 

--- a/adapters/types.go
+++ b/adapters/types.go
@@ -2,7 +2,10 @@
 // from different CLI coding agents (Claude Code, Gemini CLI, OpenAI Codex, opencode).
 package adapters
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // Session represents a unified view of an AI assistant session, regardless of the source agent.
 // Each session contains metadata about when it occurred, what was discussed, and how to retrieve its full content.
@@ -46,6 +49,22 @@ type Message struct {
 
 	// Metadata contains agent-specific additional data (e.g., tool calls, thinking blocks)
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// extractFirstLine extracts the first non-empty line from text, truncating if needed.
+// This is a shared helper used by multiple adapters for extracting message previews.
+func extractFirstLine(text string) string {
+	lines := strings.Split(text, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			if len(trimmed) > 200 {
+				return trimmed[:200] + "..."
+			}
+			return trimmed
+		}
+	}
+	return ""
 }
 
 // SessionAdapter is the interface that each agent-specific adapter must implement.

--- a/cmd/ai-sessions/cli.go
+++ b/cmd/ai-sessions/cli.go
@@ -361,6 +361,8 @@ func getAgentDisplayName(source string) string {
 		return "Gemini CLI"
 	case "mistral":
 		return "Mistral Vibe"
+	case "copilot":
+		return "Copilot CLI"
 	default:
 		if source == "" {
 			return "Unknown"
@@ -475,6 +477,13 @@ func selectSessionInteractively() (string, error) {
 	if mistralAdapter, mistralErr := adapters.NewMistralAdapter(); mistralErr == nil {
 		if mistralSessions, listErr := mistralAdapter.ListSessions("", 50); listErr == nil {
 			sessions = append(sessions, mistralSessions...)
+		}
+	}
+
+	// Try to load Copilot CLI sessions
+	if copilotAdapter, copilotErr := adapters.NewCopilotAdapter(); copilotErr == nil {
+		if copilotSessions, listErr := copilotAdapter.ListSessions("", 50); listErr == nil {
+			sessions = append(sessions, copilotSessions...)
 		}
 	}
 

--- a/cmd/ai-sessions/main.go
+++ b/cmd/ai-sessions/main.go
@@ -30,7 +30,7 @@ func main() {
 	// Otherwise, run as MCP server
 	// Create the MCP server with metadata
 	opts := &mcp.ServerOptions{
-		Instructions: "This server provides access to AI assistant CLI sessions from Claude Code, Gemini CLI, OpenAI Codex, opencode, and Mistral Vibe. Use the tools to search, list, and read previous coding sessions.",
+		Instructions: "This server provides access to AI assistant CLI sessions from Claude Code, Gemini CLI, OpenAI Codex, opencode, Mistral Vibe, and GitHub Copilot CLI. Use the tools to search, list, and read previous coding sessions.",
 	}
 
 	server := mcp.NewServer(&mcp.Implementation{
@@ -54,6 +54,9 @@ func main() {
 	}
 	if mistralAdapter, err := adapters.NewMistralAdapter(); err == nil {
 		adaptersMap["mistral"] = mistralAdapter
+	}
+	if copilotAdapter, err := adapters.NewCopilotAdapter(); err == nil {
+		adaptersMap["copilot"] = copilotAdapter
 	}
 
 	// Initialize search cache
@@ -116,7 +119,7 @@ func addListAvailableSourcesTool(server *mcp.Server, adaptersMap map[string]adap
 
 // Tool 2: list_sessions
 type listSessionsArgs struct {
-	Source      string `json:"source,omitempty" jsonschema:"Filter by source name (claude, gemini, codex, opencode, mistral). Leave empty for all sources."`
+	Source      string `json:"source,omitempty" jsonschema:"Filter by source name (claude, gemini, codex, opencode, mistral, copilot). Leave empty for all sources."`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"Filter by project directory path. Leave empty for current directory."`
 	Limit       int    `json:"limit,omitempty" jsonschema:"Maximum number of sessions to return"`
 }
@@ -186,7 +189,7 @@ func addListSessionsTool(server *mcp.Server, adaptersMap map[string]adapters.Ses
 // Tool 3: search_sessions
 type searchSessionsArgs struct {
 	Query       string `json:"query" jsonschema:"Search query to find in session content"`
-	Source      string `json:"source,omitempty" jsonschema:"Filter by source name (claude, gemini, codex, opencode, mistral). Leave empty for all sources."`
+	Source      string `json:"source,omitempty" jsonschema:"Filter by source name (claude, gemini, codex, opencode, mistral, copilot). Leave empty for all sources."`
 	ProjectPath string `json:"project_path,omitempty" jsonschema:"Filter by project directory path. Leave empty for current directory."`
 	Limit       int    `json:"limit,omitempty" jsonschema:"Maximum number of matching sessions to return"`
 }
@@ -313,7 +316,7 @@ func indexSessions(adaptersMap map[string]adapters.SessionAdapter, cache *search
 // Tool 4: get_session
 type getSessionArgs struct {
 	SessionID string `json:"session_id" jsonschema:"The session ID to retrieve"`
-	Source    string `json:"source" jsonschema:"The source that created this session (claude, gemini, codex, opencode, mistral)"`
+	Source    string `json:"source" jsonschema:"The source that created this session (claude, gemini, codex, opencode, mistral, copilot)"`
 	Page      int    `json:"page,omitempty" jsonschema:"Page number for pagination (0-indexed)"`
 	PageSize  int    `json:"page_size,omitempty" jsonschema:"Number of messages per page"`
 }


### PR DESCRIPTION
### **User description**
Adds support for [Copilot CLI ](https://github.com/github/copilot-cli)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds complete Copilot CLI session adapter implementation

- Parses JSONL session files from ~/.copilot/session-state/

- Extracts metadata, messages, and tool execution events

- Integrates Copilot adapter into CLI and MCP server

- Updates documentation strings to include Copilot CLI


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Copilot CLI<br/>Session Files"] -->|Parse JSONL| B["CopilotAdapter"]
  B -->|ListSessions| C["Session Metadata"]
  B -->|GetSession| D["Messages & Events"]
  B -->|SearchSessions| E["Query Results"]
  C -->|Integrate| F["CLI & MCP Server"]
  D -->|Integrate| F
  E -->|Integrate| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copilot.go</strong><dd><code>Complete Copilot CLI adapter implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

adapters/copilot.go

<ul><li>Implements <code>CopilotAdapter</code> struct with methods for listing, retrieving, <br>and searching sessions<br> <li> Parses JSONL session files from <code>~/.copilot/session-state/</code> directory<br> <li> Extracts session metadata including ID, timestamp, project path, and <br>user message count<br> <li> Reads and reconstructs conversation messages with support for user, <br>assistant, and tool execution events<br> <li> Implements project path inference from folder trust messages and file <br>paths in tool calls</ul>


</details>


  </td>
  <td><a href="https://github.com/yoavf/ai-sessions-mcp/pull/9/files#diff-60731096e32adbd83b287ce1aaa67ba57cb62588c244ba2a8d5ff911d00ab247">+457/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cli.go</strong><dd><code>Integrate Copilot adapter into CLI selection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ai-sessions/cli.go

<ul><li>Adds "Copilot CLI" display name mapping for copilot source<br> <li> Integrates Copilot adapter into interactive session selection<br> <li> Loads up to 50 Copilot sessions when user selects interactively</ul>


</details>


  </td>
  <td><a href="https://github.com/yoavf/ai-sessions-mcp/pull/9/files#diff-4fcf0247b2c130f11e041c6e0c06de64778532cdbb6034033915dd0a52aa9458">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Register Copilot adapter and update documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cmd/ai-sessions/main.go

<ul><li>Initializes <code>CopilotAdapter</code> in adaptersMap for MCP server<br> <li> Updates server instructions to include GitHub Copilot CLI<br> <li> Updates tool documentation strings to list copilot as available source<br> <li> Adds copilot to source filter options in list_sessions, <br>search_sessions, and get_session tools</ul>


</details>


  </td>
  <td><a href="https://github.com/yoavf/ai-sessions-mcp/pull/9/files#diff-3dc8453592a0f42c3cfcce3de0746b0222e82dade41f4e97090b1221482c1366">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

