### PR TITLE
Support current Copilot, OpenCode, Gemini, and Codex session formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,11 @@ Once configured as an MCP server, you can ask:
 The server reads session files stored locally by various CLI coding agents:
 
 - **Claude Code**: `~/.claude/projects/[PROJECT_DIR]/*.jsonl`
-- **Gemini CLI**: `~/.gemini/tmp/[PROJECT_HASH]/chats/session-*.json`
+- **Gemini CLI**: `~/.gemini/tmp/[PROJECT_HASH]/chats/session-*.jsonl` (plus legacy `.json` recordings)
 - **OpenAI Codex**: `~/.codex/sessions/` and `~/.codex/archived_sessions/`
-- **opencode**: `~/.local/share/opencode/storage/`
+- **opencode**: `~/.local/share/opencode/opencode.db` (plus the legacy `storage/` JSON tree)
 - **Mistral Vibe**: `~/.vibe/logs/session/`
-- **GitHub Copilot CLI**: `~/.copilot/session-state/`
+- **GitHub Copilot CLI**: `~/.copilot/session-state/[SESSION_ID]/events.jsonl` (plus legacy flat JSONL files)
 
 When you ask your AI agent to list or search sessions, it automatically uses these agents to access your session history.
 

--- a/adapters/codex.go
+++ b/adapters/codex.go
@@ -331,9 +331,8 @@ func (c *CodexAdapter) scanRolloutFile(filePath, targetCWD string) (*sessionInfo
 			if riType, ok := entry.Payload["type"].(string); ok && riType == "message" {
 				if role, ok := entry.Payload["role"].(string); ok && role == "user" {
 					if content, ok := entry.Payload["content"].([]interface{}); ok {
-						text := c.extractUserText(content)
-						trimmed := strings.TrimSpace(text)
-						if trimmed == "" || c.isSessionPrefix(trimmed) {
+						text := c.stripSessionPrefixes(c.extractUserText(content))
+						if text == "" {
 							continue
 						}
 
@@ -382,15 +381,82 @@ func (c *CodexAdapter) extractUserText(content []interface{}) string {
 	return strings.Join(parts, "")
 }
 
-// isSessionPrefix checks if a message is a session prefix (user_instructions or environment_context).
-// The text parameter is expected to already be trimmed.
+// isSessionPrefix checks whether a user-role message is composed entirely of
+// provider-local context envelopes.
 func (c *CodexAdapter) isSessionPrefix(text string) bool {
-	if text == "" {
+	trimmed := strings.TrimSpace(text)
+	return trimmed != "" && c.stripSessionPrefixes(trimmed) == ""
+}
+
+// stripSessionPrefixes removes provider-local XML envelopes from the start of
+// a user-role message. Current Codex versions may concatenate several
+// input_text blocks, such as recommended_plugins and environment_context, into
+// one message. Returning any remainder preserves a real prompt that happens to
+// share the same message record.
+func (c *CodexAdapter) stripSessionPrefixes(text string) string {
+	remaining := strings.TrimSpace(text)
+	for remaining != "" {
+		openingEnd := strings.IndexByte(remaining, '>')
+		if openingEnd < 2 || remaining[0] != '<' || remaining[1] == '/' {
+			break
+		}
+
+		opening := strings.TrimSpace(remaining[1:openingEnd])
+		selfClosing := strings.HasSuffix(opening, "/")
+		opening = strings.TrimSpace(strings.TrimSuffix(opening, "/"))
+		nameEnd := strings.IndexAny(opening, " \t\r\n")
+		if nameEnd >= 0 {
+			opening = opening[:nameEnd]
+		}
+		if !isCodexContextEnvelope(opening) {
+			break
+		}
+
+		if selfClosing {
+			remaining = strings.TrimSpace(remaining[openingEnd+1:])
+			continue
+		}
+
+		closingTag := "</" + strings.ToLower(opening) + ">"
+		afterOpening := remaining[openingEnd+1:]
+		closingStart := strings.Index(strings.ToLower(afterOpening), closingTag)
+		if closingStart < 0 {
+			break
+		}
+		remaining = strings.TrimSpace(afterOpening[closingStart+len(closingTag):])
+	}
+	return remaining
+}
+
+func isCodexContextEnvelope(name string) bool {
+	normalized := strings.ReplaceAll(strings.ToLower(name), "-", "_")
+	switch normalized {
+	case "app_context",
+		"bash_input",
+		"bash_stderr",
+		"bash_stdout",
+		"codex_delegation",
+		"collaboration_mode",
+		"command_args",
+		"command_message",
+		"command_name",
+		"environment_context",
+		"in_app_browser_context",
+		"local_command_caveat",
+		"local_command_stderr",
+		"local_command_stdout",
+		"permissions",
+		"realtime_delegation",
+		"recommended_plugins",
+		"skill",
+		"system_reminder",
+		"task_notification",
+		"turn_aborted",
+		"user_instructions":
+		return true
+	default:
 		return false
 	}
-	lower := strings.ToLower(text)
-	return (strings.HasPrefix(lower, "<user_instructions>") && strings.HasSuffix(lower, "</user_instructions>")) ||
-		(strings.HasPrefix(lower, "<environment_context>") && strings.HasSuffix(lower, "</environment_context>"))
 }
 
 // extractFirstLine extracts the first non-empty line from text.
@@ -508,8 +574,11 @@ func (c *CodexAdapter) readAllMessages(filePath string) ([]Message, error) {
 				}
 
 				// Skip session prefix messages
-				if role == "user" && c.isSessionPrefix(strings.TrimSpace(message.Content)) {
-					continue
+				if role == "user" {
+					message.Content = c.stripSessionPrefixes(message.Content)
+					if message.Content == "" {
+						continue
+					}
 				}
 
 				messages = append(messages, message)

--- a/adapters/codex_test.go
+++ b/adapters/codex_test.go
@@ -23,6 +23,8 @@ func TestCodexAdapterParsesCurrentRolloutFormat(t *testing.T) {
 		`{"timestamp":"2026-08-15T12:00:00.123Z","type":"session_meta","payload":{"id":"session-123","timestamp":"2026-08-15T12:00:00.123Z","cwd":` + quoteJSON(projectPath) + `,"cli_version":"0.146.0"}}` + "\n" +
 		`{"timestamp":"2026-08-15T12:00:01Z","type":"turn_context","payload":{"cwd":` + quoteJSON(projectPath) + `}}` + "\n" +
 		`{"timestamp":"2026-08-15T12:00:02Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"developer instructions"}]}}` + "\n" +
+		`{"timestamp":"2026-08-15T12:00:02.500Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<recommended_plugins>plugin context</recommended_plugins>"},{"type":"input_text","text":"<environment_context>environment context</environment_context>"}]}}` + "\n" +
+		`{"timestamp":"2026-08-15T12:00:02.750Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<turn_aborted reason=\"interrupted\"/>"}]}}` + "\n" +
 		`{"timestamp":"2026-08-15T12:00:03Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Current Codex question?\nMore detail"}]}}` + "\n" +
 		`{"timestamp":"2026-08-15T12:00:04Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Current Codex answer"}]}}` + "\n"
 	if err := os.WriteFile(sessionPath, []byte(rollout), 0o600); err != nil {
@@ -53,6 +55,43 @@ func TestCodexAdapterParsesCurrentRolloutFormat(t *testing.T) {
 	}
 	if messages[2].Role != "assistant" || messages[2].Content != "Current Codex answer" {
 		t.Fatalf("unexpected assistant message: %+v", messages[2])
+	}
+}
+
+func TestCodexAdapterPreservesPromptAfterInjectedContext(t *testing.T) {
+	homeDir := t.TempDir()
+	projectPath := filepath.Join(homeDir, "project")
+	if err := os.MkdirAll(projectPath, 0o755); err != nil {
+		t.Fatalf("failed to create project: %v", err)
+	}
+
+	sessionDir := filepath.Join(homeDir, ".codex", "sessions", "2026", "08", "15")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("failed to create session directory: %v", err)
+	}
+	sessionPath := filepath.Join(sessionDir, "rollout-2026-08-15T12-00-00-session-mixed.jsonl")
+	rollout := "" +
+		`{"timestamp":"2026-08-15T12:00:00Z","type":"session_meta","payload":{"id":"session-mixed","cwd":` + quoteJSON(projectPath) + `}}` + "\n" +
+		`{"timestamp":"2026-08-15T12:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<recommended_plugins>plugin context</recommended_plugins>Real question"}]}}` + "\n"
+	if err := os.WriteFile(sessionPath, []byte(rollout), 0o600); err != nil {
+		t.Fatalf("failed to write rollout: %v", err)
+	}
+
+	adapter := &CodexAdapter{homeDir: homeDir}
+	sessions, err := adapter.ListSessions(projectPath, 10)
+	if err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].FirstMessage != "Real question" {
+		t.Fatalf("unexpected sessions: %+v", sessions)
+	}
+
+	messages, err := adapter.GetSession("session-mixed", 0, 20)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if len(messages) != 1 || messages[0].Content != "Real question" {
+		t.Fatalf("unexpected messages: %+v", messages)
 	}
 }
 

--- a/adapters/copilot.go
+++ b/adapters/copilot.go
@@ -489,8 +489,11 @@ func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([
 	query = strings.ToLower(query)
 	var matches []Session
 
-	// Read each file once and search in a single pass
-	for _, filePath := range files {
+	// Determine recency with a lightweight pass over each session.start event,
+	// then scan full contents newest-first so a small limit bounds typical work.
+	orderedFiles := orderCopilotSessionFiles(files)
+	for _, candidate := range orderedFiles {
+		filePath := candidate.path
 		session, contents, err := c.parseSessionWithContents(filePath)
 		if err != nil {
 			continue
@@ -512,6 +515,9 @@ func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([
 
 		if found {
 			matches = append(matches, session)
+			if limit > 0 && len(matches) >= limit {
+				break
+			}
 		}
 	}
 
@@ -524,6 +530,58 @@ func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([
 	}
 
 	return matches, nil
+}
+
+type copilotSessionFile struct {
+	path      string
+	timestamp time.Time
+}
+
+func orderCopilotSessionFiles(files []string) []copilotSessionFile {
+	ordered := make([]copilotSessionFile, 0, len(files))
+	for _, filePath := range files {
+		ordered = append(ordered, copilotSessionFile{
+			path:      filePath,
+			timestamp: copilotSessionStartTimestamp(filePath),
+		})
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].timestamp.After(ordered[j].timestamp)
+	})
+	return ordered
+}
+
+// copilotSessionStartTimestamp reads only until session.start, which is the
+// first event in current Copilot logs. Legacy logs without that event fall
+// back to file modification time.
+func copilotSessionStartTimestamp(filePath string) time.Time {
+	file, err := os.Open(filePath)
+	if err == nil {
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			var event copilotEvent
+			if json.Unmarshal(scanner.Bytes(), &event) != nil || event.Type != "session.start" {
+				continue
+			}
+			var data copilotSessionStart
+			if json.Unmarshal(event.Data, &data) != nil {
+				break
+			}
+			if timestamp, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
+				return timestamp
+			}
+			if timestamp, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
+				return timestamp
+			}
+			break
+		}
+	}
+	if stat, err := os.Stat(filePath); err == nil {
+		return stat.ModTime()
+	}
+	return time.Time{}
 }
 
 // parseSessionWithContents reads a session file and returns metadata plus all message contents.

--- a/adapters/copilot.go
+++ b/adapters/copilot.go
@@ -551,31 +551,28 @@ func orderCopilotSessionFiles(files []string) []copilotSessionFile {
 	return ordered
 }
 
-// copilotSessionStartTimestamp reads only until session.start, which is the
-// first event in current Copilot logs. Legacy logs without that event fall
-// back to file modification time.
+// copilotSessionStartTimestamp inspects the first event, where session.start
+// appears in current Copilot logs. Legacy logs fall back to file modification
+// time without an additional full-file scan.
 func copilotSessionStartTimestamp(filePath string) time.Time {
 	file, err := os.Open(filePath)
 	if err == nil {
 		defer file.Close()
 		scanner := bufio.NewScanner(file)
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-		for scanner.Scan() {
+		if scanner.Scan() {
 			var event copilotEvent
-			if json.Unmarshal(scanner.Bytes(), &event) != nil || event.Type != "session.start" {
-				continue
+			if json.Unmarshal(scanner.Bytes(), &event) == nil && event.Type == "session.start" {
+				var data copilotSessionStart
+				if json.Unmarshal(event.Data, &data) == nil {
+					if timestamp, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
+						return timestamp
+					}
+					if timestamp, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
+						return timestamp
+					}
+				}
 			}
-			var data copilotSessionStart
-			if json.Unmarshal(event.Data, &data) != nil {
-				break
-			}
-			if timestamp, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
-				return timestamp
-			}
-			if timestamp, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
-				return timestamp
-			}
-			break
 		}
 	}
 	if stat, err := os.Stat(filePath); err == nil {

--- a/adapters/copilot.go
+++ b/adapters/copilot.go
@@ -50,6 +50,10 @@ type copilotSessionStart struct {
 	Producer       string `json:"producer"`
 	CopilotVersion string `json:"copilotVersion"`
 	StartTime      string `json:"startTime"`
+	Context        struct {
+		CWD     string `json:"cwd"`
+		GitRoot string `json:"gitRoot"`
+	} `json:"context"`
 }
 
 // copilotSessionInfo represents the data for a session.info event.
@@ -112,8 +116,7 @@ func (c *CopilotAdapter) ListSessions(projectPath string, limit int) ([]Session,
 		}
 	}
 
-	// Read all *.jsonl files
-	files, err := filepath.Glob(filepath.Join(sessionsDir, "*.jsonl"))
+	files, err := c.sessionFiles(sessionsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list session files: %w", err)
 	}
@@ -145,6 +148,26 @@ func (c *CopilotAdapter) ListSessions(projectPath string, limit int) ([]Session,
 	}
 
 	return sessions, nil
+}
+
+// sessionFiles returns both current Copilot session logs and the legacy flat
+// JSONL layout. Current Copilot versions store each log at
+// session-state/<session-id>/events.jsonl.
+func (c *CopilotAdapter) sessionFiles(sessionsDir string) ([]string, error) {
+	patterns := []string{
+		filepath.Join(sessionsDir, "*", "events.jsonl"),
+		filepath.Join(sessionsDir, "*.jsonl"),
+	}
+
+	var files []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, matches...)
+	}
+	return files, nil
 }
 
 // parseSessionMetadata extracts metadata from a Copilot CLI session file.
@@ -183,6 +206,11 @@ func (c *CopilotAdapter) parseSessionMetadata(filePath string) (Session, error) 
 			var data copilotSessionStart
 			if err := json.Unmarshal(event.Data, &data); err == nil {
 				session.ID = data.SessionID
+				if data.Context.CWD != "" {
+					session.ProjectPath = data.Context.CWD
+				} else if data.Context.GitRoot != "" {
+					session.ProjectPath = data.Context.GitRoot
+				}
 				if ts, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
 					session.Timestamp = ts
 				} else if ts, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
@@ -240,11 +268,17 @@ func (c *CopilotAdapter) parseSessionMetadata(filePath string) (Session, error) 
 
 	// Extract session ID from filename if not found in content
 	if session.ID == "" {
-		base := filepath.Base(filePath)
-		session.ID = strings.TrimSuffix(base, ".jsonl")
+		session.ID = copilotSessionIDFromPath(filePath)
 	}
 
 	return session, nil
+}
+
+func copilotSessionIDFromPath(filePath string) string {
+	if filepath.Base(filePath) == "events.jsonl" {
+		return filepath.Base(filepath.Dir(filePath))
+	}
+	return strings.TrimSuffix(filepath.Base(filePath), ".jsonl")
 }
 
 // findCommonDirectory finds the longest common directory path from a list of file paths.
@@ -273,9 +307,8 @@ func findCommonDirectory(paths []string) string {
 func (c *CopilotAdapter) GetSession(sessionID string, page, pageSize int) ([]Message, error) {
 	sessionsDir := filepath.Join(c.homeDir, ".copilot", "session-state")
 
-	// Try to find the session file directly by ID
-	sessionFile := filepath.Join(sessionsDir, sessionID+".jsonl")
-	if _, err := os.Stat(sessionFile); os.IsNotExist(err) {
+	sessionFile := c.resolveSessionFile(sessionsDir, sessionID)
+	if sessionFile == "" {
 		return nil, fmt.Errorf("session not found: %s", sessionID)
 	}
 
@@ -297,6 +330,19 @@ func (c *CopilotAdapter) GetSession(sessionID string, page, pageSize int) ([]Mes
 	}
 
 	return messages[start:end], nil
+}
+
+func (c *CopilotAdapter) resolveSessionFile(sessionsDir, sessionID string) string {
+	candidates := []string{
+		filepath.Join(sessionsDir, sessionID, "events.jsonl"),
+		filepath.Join(sessionsDir, sessionID+".jsonl"),
+	}
+	for _, candidate := range candidates {
+		if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+			return candidate
+		}
+	}
+	return ""
 }
 
 // readAllMessages reads all messages from a Copilot CLI session file.
@@ -435,7 +481,7 @@ func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([
 		}
 	}
 
-	files, err := filepath.Glob(filepath.Join(sessionsDir, "*.jsonl"))
+	files, err := c.sessionFiles(sessionsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list session files: %w", err)
 	}
@@ -466,9 +512,6 @@ func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([
 
 		if found {
 			matches = append(matches, session)
-			if limit > 0 && len(matches) >= limit {
-				break
-			}
 		}
 	}
 
@@ -476,6 +519,9 @@ func (c *CopilotAdapter) SearchSessions(projectPath, query string, limit int) ([
 	sort.Slice(matches, func(i, j int) bool {
 		return matches[i].Timestamp.After(matches[j].Timestamp)
 	})
+	if limit > 0 && len(matches) > limit {
+		matches = matches[:limit]
+	}
 
 	return matches, nil
 }
@@ -514,6 +560,11 @@ func (c *CopilotAdapter) parseSessionWithContents(filePath string) (Session, []s
 			var data copilotSessionStart
 			if err := json.Unmarshal(event.Data, &data); err == nil {
 				session.ID = data.SessionID
+				if data.Context.CWD != "" {
+					session.ProjectPath = data.Context.CWD
+				} else if data.Context.GitRoot != "" {
+					session.ProjectPath = data.Context.GitRoot
+				}
 				if ts, err := time.Parse(time.RFC3339Nano, data.StartTime); err == nil {
 					session.Timestamp = ts
 				} else if ts, err := time.Parse(time.RFC3339, data.StartTime); err == nil {
@@ -573,8 +624,7 @@ func (c *CopilotAdapter) parseSessionWithContents(filePath string) (Session, []s
 	}
 
 	if session.ID == "" {
-		base := filepath.Base(filePath)
-		session.ID = strings.TrimSuffix(base, ".jsonl")
+		session.ID = copilotSessionIDFromPath(filePath)
 	}
 
 	return session, contents, nil

--- a/adapters/copilot_test.go
+++ b/adapters/copilot_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestCopilotAdapterReadsNestedSessionLayout(t *testing.T) {
@@ -72,5 +73,39 @@ func TestCopilotAdapterKeepsLegacyFlatLayout(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0].ID != "legacy" {
 		t.Fatalf("unexpected legacy sessions: %+v", sessions)
+	}
+}
+
+func TestCopilotSearchLimitReturnsNewestMatch(t *testing.T) {
+	home := t.TempDir()
+	sessionsDir := filepath.Join(home, ".copilot", "session-state")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeSession := func(name, sessionID, startTime string) {
+		t.Helper()
+		contents := `{"type":"session.start","data":{"sessionId":"` + sessionID + `","startTime":"` + startTime + `"}}` + "\n" +
+			`{"type":"user.message","data":{"content":"matching prompt"}}` + "\n"
+		if err := os.WriteFile(filepath.Join(sessionsDir, name+".jsonl"), []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Lexical file order is intentionally the reverse of session recency.
+	writeSession("a-older", "older", "2026-08-16T10:00:00Z")
+	writeSession("z-newer", "newer", "2026-08-17T10:00:00Z")
+
+	adapter := &CopilotAdapter{homeDir: home}
+	matches, err := adapter.SearchSessions("", "matching", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].ID != "newer" {
+		t.Fatalf("expected newest matching session, got %+v", matches)
+	}
+	wantTimestamp := time.Date(2026, 8, 17, 10, 0, 0, 0, time.UTC)
+	if !matches[0].Timestamp.Equal(wantTimestamp) {
+		t.Fatalf("timestamp = %v, want %v", matches[0].Timestamp, wantTimestamp)
 	}
 }

--- a/adapters/copilot_test.go
+++ b/adapters/copilot_test.go
@@ -1,0 +1,76 @@
+package adapters
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopilotAdapterReadsNestedSessionLayout(t *testing.T) {
+	home := t.TempDir()
+	project := filepath.Join(home, "project")
+	sessionID := "current-session"
+	sessionDir := filepath.Join(home, ".copilot", "session-state", sessionID)
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	events := `{"type":"session.start","data":{"sessionId":"current-session","startTime":"2026-08-14T12:00:00Z","context":{"cwd":"` + project + `","gitRoot":"` + project + `"}}}
+{"type":"user.message","timestamp":"2026-08-14T12:00:01Z","data":{"content":"Find the compatibility bug"}}
+{"type":"assistant.message","timestamp":"2026-08-14T12:00:02Z","data":{"content":"Found it"}}
+`
+	eventsPath := filepath.Join(sessionDir, "events.jsonl")
+	if err := os.WriteFile(eventsPath, []byte(events), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := &CopilotAdapter{homeDir: home}
+	sessions, err := adapter.ListSessions(project, 0)
+	if err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected one session, got %d", len(sessions))
+	}
+	if sessions[0].ID != sessionID || sessions[0].ProjectPath != project {
+		t.Fatalf("unexpected session metadata: %+v", sessions[0])
+	}
+
+	messages, err := adapter.GetSession(sessionID, 0, 10)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if len(messages) != 2 || messages[0].Content != "Find the compatibility bug" {
+		t.Fatalf("unexpected messages: %+v", messages)
+	}
+
+	matches, err := adapter.SearchSessions(project, "found it", 0)
+	if err != nil {
+		t.Fatalf("SearchSessions returned error: %v", err)
+	}
+	if len(matches) != 1 || matches[0].ID != sessionID {
+		t.Fatalf("unexpected search results: %+v", matches)
+	}
+}
+
+func TestCopilotAdapterKeepsLegacyFlatLayout(t *testing.T) {
+	home := t.TempDir()
+	sessionsDir := filepath.Join(home, ".copilot", "session-state")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionsDir, "legacy.jsonl"), []byte(
+		"{\"type\":\"user.message\",\"data\":{\"content\":\"legacy\"}}\n",
+	), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := &CopilotAdapter{homeDir: home}
+	sessions, err := adapter.ListSessions("", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "legacy" {
+		t.Fatalf("unexpected legacy sessions: %+v", sessions)
+	}
+}

--- a/adapters/copilot_test.go
+++ b/adapters/copilot_test.go
@@ -109,3 +109,20 @@ func TestCopilotSearchLimitReturnsNewestMatch(t *testing.T) {
 		t.Fatalf("timestamp = %v, want %v", matches[0].Timestamp, wantTimestamp)
 	}
 }
+
+func TestCopilotSessionTimestampFallsBackWhenFirstEventIsNotSessionStart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.jsonl")
+	events := `{"type":"user.message","data":{"content":"legacy prompt"}}` + "\n" +
+		`{"type":"session.start","data":{"sessionId":"not-current-format","startTime":"2026-08-17T10:00:00Z"}}` + "\n"
+	if err := os.WriteFile(path, []byte(events), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	modTime := time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := copilotSessionStartTimestamp(path); !got.Equal(modTime) {
+		t.Fatalf("timestamp = %v, want file modification time %v", got, modTime)
+	}
+}

--- a/adapters/gemini.go
+++ b/adapters/gemini.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -299,12 +300,10 @@ func loadGeminiSession(filePath string) (*geminiSession, error) {
 		}
 	}
 
-	scanner := bufio.NewScanner(file)
-	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
-	for scanner.Scan() {
+	processRecord := func(line []byte) {
 		var record map[string]json.RawMessage
-		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
-			continue
+		if err := json.Unmarshal(line, &record); err != nil {
+			return
 		}
 
 		if value, ok := record["$rewindTo"]; ok {
@@ -318,7 +317,7 @@ func loadGeminiSession(filePath string) (*geminiSession, error) {
 					clear(messageIndex)
 				}
 			}
-			continue
+			return
 		}
 
 		if value, ok := record["$set"]; ok {
@@ -326,13 +325,13 @@ func loadGeminiSession(filePath string) (*geminiSession, error) {
 			if json.Unmarshal(value, &update) == nil {
 				applyMetadata(update)
 			}
-			continue
+			return
 		}
 
 		if _, hasID := record["id"]; hasID {
 			if _, hasType := record["type"]; hasType {
 				var message geminiMessage
-				if json.Unmarshal(scanner.Bytes(), &message) == nil {
+				if json.Unmarshal(line, &message) == nil {
 					if index, found := messageIndex[message.ID]; found {
 						session.Messages[index] = message
 					} else {
@@ -340,14 +339,25 @@ func loadGeminiSession(filePath string) (*geminiSession, error) {
 						session.Messages = append(session.Messages, message)
 					}
 				}
-				continue
+				return
 			}
 		}
 
 		applyMetadata(record)
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("failed to parse session JSONL: %w", err)
+
+	reader := bufio.NewReader(file)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			processRecord(line)
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to parse session JSONL: %w", readErr)
+		}
 	}
 	if session.SessionID == "" {
 		return nil, fmt.Errorf("failed to parse session JSONL: missing sessionId")

--- a/adapters/gemini.go
+++ b/adapters/gemini.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,6 +14,10 @@ import (
 	"strings"
 	"time"
 )
+
+const maxGeminiJSONLRecordSize = 50 << 20
+
+var errGeminiJSONLRecordTooLarge = errors.New("Gemini JSONL record exceeds maximum size")
 
 // GeminiAdapter implements SessionAdapter for Gemini CLI sessions.
 // Gemini stores sessions as JSON files in ~/.gemini/tmp/[PROJECT_HASH]/chats/
@@ -348,21 +353,44 @@ func loadGeminiSession(filePath string) (*geminiSession, error) {
 
 	reader := bufio.NewReader(file)
 	for {
-		line, readErr := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			processRecord(line)
-		}
-		if readErr == io.EOF {
+		line, readErr := readGeminiJSONLRecord(reader, maxGeminiJSONLRecordSize)
+		if errors.Is(readErr, io.EOF) {
 			break
 		}
 		if readErr != nil {
 			return nil, fmt.Errorf("failed to parse session JSONL: %w", readErr)
 		}
+		processRecord(line)
 	}
 	if session.SessionID == "" {
 		return nil, fmt.Errorf("failed to parse session JSONL: missing sessionId")
 	}
 	return session, nil
+}
+
+func readGeminiJSONLRecord(reader *bufio.Reader, maxSize int) ([]byte, error) {
+	record := make([]byte, 0, reader.Size())
+	for {
+		fragment, readErr := reader.ReadSlice('\n')
+		if len(fragment) > maxSize || len(record) > maxSize-len(fragment) {
+			return nil, fmt.Errorf("%w: limit is %d bytes", errGeminiJSONLRecordTooLarge, maxSize)
+		}
+		record = append(record, fragment...)
+
+		switch {
+		case readErr == nil:
+			return record, nil
+		case errors.Is(readErr, bufio.ErrBufferFull):
+			continue
+		case errors.Is(readErr, io.EOF):
+			if len(record) == 0 {
+				return nil, io.EOF
+			}
+			return record, nil
+		default:
+			return nil, readErr
+		}
+	}
 }
 
 // extractFirstLineFromContent extracts the first line from various content formats.

--- a/adapters/gemini.go
+++ b/adapters/gemini.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -39,13 +40,17 @@ func (g *GeminiAdapter) Name() string {
 
 // geminiSession represents the structure of a Gemini session JSON file.
 type geminiSession struct {
-	SessionID string          `json:"sessionId"`
-	StartTime string          `json:"startTime,omitempty"`
-	Messages  []geminiMessage `json:"messages"`
+	SessionID   string          `json:"sessionId"`
+	ProjectHash string          `json:"projectHash,omitempty"`
+	StartTime   string          `json:"startTime,omitempty"`
+	LastUpdated string          `json:"lastUpdated,omitempty"`
+	Summary     string          `json:"summary,omitempty"`
+	Messages    []geminiMessage `json:"messages"`
 }
 
 // geminiMessage represents a single message in a Gemini session.
 type geminiMessage struct {
+	ID        string           `json:"id,omitempty"`
 	Role      string           `json:"role,omitempty"`
 	Type      string           `json:"type,omitempty"`
 	Content   interface{}      `json:"content"`
@@ -90,8 +95,8 @@ func (g *GeminiAdapter) ListSessions(projectPath string, limit int) ([]Session, 
 		return []Session{}, nil // No sessions for this project
 	}
 
-	// Read all session-*.json files
-	files, err := filepath.Glob(filepath.Join(chatsDir, "session-*.json"))
+	// Read current JSONL recordings and legacy JSON recordings.
+	files, err := geminiSessionFiles(chatsDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list session files: %w", err)
 	}
@@ -139,7 +144,7 @@ func (g *GeminiAdapter) listAllSessions(geminiTmpDir string, limit int) ([]Sessi
 		}
 
 		chatsDir := filepath.Join(geminiTmpDir, dir.Name(), "chats")
-		files, err := filepath.Glob(filepath.Join(chatsDir, "session-*.json"))
+		files, err := geminiSessionFiles(chatsDir)
 		if err != nil {
 			continue
 		}
@@ -167,26 +172,38 @@ func (g *GeminiAdapter) listAllSessions(geminiTmpDir string, limit int) ([]Sessi
 	return allSessions, nil
 }
 
+func geminiSessionFiles(chatsDir string) ([]string, error) {
+	patterns := []string{
+		filepath.Join(chatsDir, "session-*.jsonl"),
+		filepath.Join(chatsDir, "session-*.json"),
+	}
+	var files []string
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, matches...)
+	}
+	return files, nil
+}
+
 // parseSessionMetadata extracts metadata from a Gemini session file.
 func (g *GeminiAdapter) parseSessionMetadata(filePath, projectPath string) (Session, error) {
-	data, err := os.ReadFile(filePath)
+	geminiSess, err := loadGeminiSession(filePath)
 	if err != nil {
-		return Session{}, fmt.Errorf("failed to read session file: %w", err)
-	}
-
-	var geminiSess geminiSession
-	if err := json.Unmarshal(data, &geminiSess); err != nil {
-		return Session{}, fmt.Errorf("failed to parse session JSON: %w", err)
+		return Session{}, err
 	}
 
 	hashDir := extractHashFromPath(filePath)
-	resolvedProjectPath := g.resolveProjectPath(hashDir, projectPath, &geminiSess)
+	resolvedProjectPath := g.resolveProjectPath(hashDir, projectPath, geminiSess)
 
 	session := Session{
 		ID:          geminiSess.SessionID,
 		Source:      "gemini",
 		ProjectPath: resolvedProjectPath,
 		FilePath:    filePath,
+		Summary:     geminiSess.Summary,
 	}
 
 	// Parse timestamp from first message or startTime
@@ -222,6 +239,119 @@ func (g *GeminiAdapter) parseSessionMetadata(filePath, projectPath string) (Sess
 
 	session.UserMessageCount = userCount
 
+	return session, nil
+}
+
+// loadGeminiSession supports both legacy whole-document JSON recordings and
+// current append-only JSONL recordings. JSONL files may contain metadata
+// updates, message replacements, and rewind markers.
+func loadGeminiSession(filePath string) (*geminiSession, error) {
+	if filepath.Ext(filePath) == ".json" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read session file: %w", err)
+		}
+		var session geminiSession
+		if err := json.Unmarshal(data, &session); err != nil {
+			return nil, fmt.Errorf("failed to parse session JSON: %w", err)
+		}
+		return &session, nil
+	}
+
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read session file: %w", err)
+	}
+	defer file.Close()
+
+	session := &geminiSession{}
+	messageIndex := make(map[string]int)
+	rebuildIndex := func() {
+		clear(messageIndex)
+		for i, message := range session.Messages {
+			if message.ID != "" {
+				messageIndex[message.ID] = i
+			}
+		}
+	}
+	applyMetadata := func(raw map[string]json.RawMessage) {
+		if value, ok := raw["sessionId"]; ok {
+			_ = json.Unmarshal(value, &session.SessionID)
+		}
+		if value, ok := raw["projectHash"]; ok {
+			_ = json.Unmarshal(value, &session.ProjectHash)
+		}
+		if value, ok := raw["startTime"]; ok {
+			_ = json.Unmarshal(value, &session.StartTime)
+		}
+		if value, ok := raw["lastUpdated"]; ok {
+			_ = json.Unmarshal(value, &session.LastUpdated)
+		}
+		if value, ok := raw["summary"]; ok {
+			_ = json.Unmarshal(value, &session.Summary)
+		}
+		if value, ok := raw["messages"]; ok {
+			var messages []geminiMessage
+			if json.Unmarshal(value, &messages) == nil {
+				session.Messages = messages
+				rebuildIndex()
+			}
+		}
+	}
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024)
+	for scanner.Scan() {
+		var record map[string]json.RawMessage
+		if err := json.Unmarshal(scanner.Bytes(), &record); err != nil {
+			continue
+		}
+
+		if value, ok := record["$rewindTo"]; ok {
+			var messageID string
+			if json.Unmarshal(value, &messageID) == nil {
+				if index, found := messageIndex[messageID]; found {
+					session.Messages = session.Messages[:index]
+					rebuildIndex()
+				} else {
+					session.Messages = nil
+					clear(messageIndex)
+				}
+			}
+			continue
+		}
+
+		if value, ok := record["$set"]; ok {
+			var update map[string]json.RawMessage
+			if json.Unmarshal(value, &update) == nil {
+				applyMetadata(update)
+			}
+			continue
+		}
+
+		if _, hasID := record["id"]; hasID {
+			if _, hasType := record["type"]; hasType {
+				var message geminiMessage
+				if json.Unmarshal(scanner.Bytes(), &message) == nil {
+					if index, found := messageIndex[message.ID]; found {
+						session.Messages[index] = message
+					} else {
+						messageIndex[message.ID] = len(session.Messages)
+						session.Messages = append(session.Messages, message)
+					}
+				}
+				continue
+			}
+		}
+
+		applyMetadata(record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to parse session JSONL: %w", err)
+	}
+	if session.SessionID == "" {
+		return nil, fmt.Errorf("failed to parse session JSONL: missing sessionId")
+	}
 	return session, nil
 }
 
@@ -275,20 +405,15 @@ func (g *GeminiAdapter) GetSession(sessionID string, page, pageSize int) ([]Mess
 
 		// Check for matching session file
 		chatsDir := filepath.Join(geminiTmpDir, dir.Name(), "chats")
-		files, err := filepath.Glob(filepath.Join(chatsDir, "session-*.json"))
+		files, err := geminiSessionFiles(chatsDir)
 		if err != nil {
 			continue
 		}
 
 		for _, file := range files {
 			// Read and check if this is the right session
-			data, err := os.ReadFile(file)
+			sess, err := loadGeminiSession(file)
 			if err != nil {
-				continue
-			}
-
-			var sess geminiSession
-			if err := json.Unmarshal(data, &sess); err != nil {
 				continue
 			}
 
@@ -329,14 +454,9 @@ func (g *GeminiAdapter) GetSession(sessionID string, page, pageSize int) ([]Mess
 
 // readAllMessages reads all messages from a Gemini session file.
 func (g *GeminiAdapter) readAllMessages(filePath string) ([]Message, error) {
-	data, err := os.ReadFile(filePath)
+	sess, err := loadGeminiSession(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read session file: %w", err)
-	}
-
-	var sess geminiSession
-	if err := json.Unmarshal(data, &sess); err != nil {
-		return nil, fmt.Errorf("failed to parse session JSON: %w", err)
+		return nil, err
 	}
 
 	messages := make([]Message, 0, len(sess.Messages))

--- a/adapters/gemini_test.go
+++ b/adapters/gemini_test.go
@@ -2,8 +2,10 @@ package adapters
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -178,5 +180,35 @@ func TestGeminiAdapterReadsCurrentJSONLRecordings(t *testing.T) {
 	}
 	if len(messages) != 2 || messages[1].Content != "Current answer" {
 		t.Fatalf("unexpected JSONL messages: %+v", messages)
+	}
+}
+
+func TestLoadGeminiSessionAcceptsJSONLRecordLargerThanTenMiB(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session-large.jsonl")
+	largeContent := strings.Repeat("x", 10*1024*1024+1)
+	metadata := `{"sessionId":"large-session","projectHash":"hash","startTime":"2026-08-17T10:00:00Z"}`
+	message, err := json.Marshal(geminiMessage{
+		ID:      "large-message",
+		Type:    "user",
+		Content: largeContent,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents := append([]byte(metadata+"\n"), message...)
+	contents = append(contents, '\n')
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := loadGeminiSession(path)
+	if err != nil {
+		t.Fatalf("loadGeminiSession returned error: %v", err)
+	}
+	if len(session.Messages) != 1 {
+		t.Fatalf("expected one message, got %d", len(session.Messages))
+	}
+	if got := session.Messages[0].Content; got != largeContent {
+		t.Fatalf("large message content was not preserved: got %T with length %d", got, len(fmt.Sprint(got)))
 	}
 }

--- a/adapters/gemini_test.go
+++ b/adapters/gemini_test.go
@@ -1,7 +1,9 @@
 package adapters
 
 import (
+	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -210,5 +212,12 @@ func TestLoadGeminiSessionAcceptsJSONLRecordLargerThanTenMiB(t *testing.T) {
 	}
 	if got := session.Messages[0].Content; got != largeContent {
 		t.Fatalf("large message content was not preserved: got %T with length %d", got, len(fmt.Sprint(got)))
+	}
+}
+
+func TestReadGeminiJSONLRecordEnforcesLimit(t *testing.T) {
+	reader := bufio.NewReaderSize(strings.NewReader("12345678\n"), 4)
+	if _, err := readGeminiJSONLRecord(reader, 8); !errors.Is(err, errGeminiJSONLRecordTooLarge) {
+		t.Fatalf("readGeminiJSONLRecord error = %v, want %v", err, errGeminiJSONLRecordTooLarge)
 	}
 }

--- a/adapters/gemini_test.go
+++ b/adapters/gemini_test.go
@@ -138,3 +138,45 @@ func TestNormalizeGeminiRole(t *testing.T) {
 		}
 	}
 }
+
+func TestGeminiAdapterReadsCurrentJSONLRecordings(t *testing.T) {
+	home := t.TempDir()
+	projectPath := filepath.Join(home, "project")
+	hash := hashProjectPath(projectPath)
+	chatsDir := filepath.Join(home, ".gemini", "tmp", hash, "chats")
+	if err := os.MkdirAll(chatsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	recording := `{"sessionId":"jsonl-session","projectHash":"` + hash + `","startTime":"2026-08-11T10:00:00Z","lastUpdated":"2026-08-11T10:01:00Z"}
+{"id":"user-1","timestamp":"2026-08-11T10:00:01Z","type":"user","content":[{"text":"First current prompt"}]}
+{"id":"gemini-1","timestamp":"2026-08-11T10:00:02Z","type":"gemini","content":[{"text":"Superseded answer"}]}
+{"$rewindTo":"gemini-1"}
+{"id":"gemini-2","timestamp":"2026-08-11T10:00:03Z","type":"gemini","content":[{"text":"Current answer"}]}
+{"$set":{"summary":"Current JSONL session"}}
+`
+	path := filepath.Join(chatsDir, "session-2026-08-11T10-00-jsonl-se.jsonl")
+	if err := os.WriteFile(path, []byte(recording), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := &GeminiAdapter{homeDir: home, projectCache: make(map[string]string)}
+	sessions, err := adapter.ListSessions(projectPath, 0)
+	if err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected one session, got %d", len(sessions))
+	}
+	if sessions[0].ID != "jsonl-session" || sessions[0].FirstMessage != "First current prompt" || sessions[0].Summary != "Current JSONL session" {
+		t.Fatalf("unexpected session metadata: %+v", sessions[0])
+	}
+
+	messages, err := adapter.GetSession("jsonl-session", 0, 10)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if len(messages) != 2 || messages[1].Content != "Current answer" {
+		t.Fatalf("unexpected JSONL messages: %+v", messages)
+	}
+}

--- a/adapters/helpers_test.go
+++ b/adapters/helpers_test.go
@@ -96,11 +96,34 @@ func TestCodexIsSessionPrefix(t *testing.T) {
 	}{
 		{"<user_instructions>hi</user_instructions>", true},
 		{"<environment_context>info</environment_context>", true},
+		{"<recommended_plugins>plugins</recommended_plugins><environment_context>info</environment_context>", true},
+		{"<app-context mode=\"desktop\">info</app-context>", true},
+		{"<system-reminder>info</system-reminder><turn_aborted/>", true},
+		{"<request>real user request</request>", false},
+		{"<environment_context>info</environment_context>real user request", false},
 		{" user prompt ", false},
 	}
 	for _, tc := range table {
 		if got := adapter.isSessionPrefix(tc.text); got != tc.want {
 			t.Fatalf("isSessionPrefix(%q)=%v want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestCodexStripSessionPrefixes(t *testing.T) {
+	adapter := &CodexAdapter{}
+	table := []struct {
+		text string
+		want string
+	}{
+		{"<recommended_plugins>plugins</recommended_plugins><environment_context>info</environment_context>", ""},
+		{"<recommended_plugins>plugins</recommended_plugins>real user request", "real user request"},
+		{"<request>real user request</request>", "<request>real user request</request>"},
+		{"<recommended_plugins>unterminated", "<recommended_plugins>unterminated"},
+	}
+	for _, tc := range table {
+		if got := adapter.stripSessionPrefixes(tc.text); got != tc.want {
+			t.Fatalf("stripSessionPrefixes(%q)=%q want %q", tc.text, got, tc.want)
 		}
 	}
 }

--- a/adapters/opencode.go
+++ b/adapters/opencode.go
@@ -1,13 +1,17 @@
 package adapters
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
+
+	_ "modernc.org/sqlite"
 )
 
 // OpencodeAdapter implements SessionAdapter for opencode CLI sessions.
@@ -74,6 +78,40 @@ type opencodeMessage struct {
 // ListSessions returns all opencode sessions for the given project.
 // If projectPath is empty, returns sessions from ALL projects.
 func (o *OpencodeAdapter) ListSessions(projectPath string, limit int) ([]Session, error) {
+	databaseSessions, err := o.listDatabaseSessions(projectPath)
+	if err != nil {
+		return nil, err
+	}
+	legacySessions, err := o.listLegacySessions(projectPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prefer current SQLite records when an ID also remains in the legacy JSON
+	// migration tree, while retaining older sessions that were not migrated.
+	seen := make(map[string]struct{}, len(databaseSessions))
+	allSessions := make([]Session, 0, len(databaseSessions)+len(legacySessions))
+	for _, session := range databaseSessions {
+		seen[session.ID] = struct{}{}
+		allSessions = append(allSessions, session)
+	}
+	for _, session := range legacySessions {
+		if _, exists := seen[session.ID]; exists {
+			continue
+		}
+		allSessions = append(allSessions, session)
+	}
+
+	sort.Slice(allSessions, func(i, j int) bool {
+		return allSessions[i].Timestamp.After(allSessions[j].Timestamp)
+	})
+	if limit > 0 && len(allSessions) > limit {
+		allSessions = allSessions[:limit]
+	}
+	return allSessions, nil
+}
+
+func (o *OpencodeAdapter) listLegacySessions(projectPath string) ([]Session, error) {
 	storageDir := filepath.Join(o.homeDir, ".local", "share", "opencode", "storage")
 
 	// Check if storage directory exists
@@ -131,17 +169,113 @@ func (o *OpencodeAdapter) ListSessions(projectPath string, limit int) ([]Session
 		allSessions = append(allSessions, sessions...)
 	}
 
-	// Sort by timestamp (newest first)
-	sort.Slice(allSessions, func(i, j int) bool {
-		return allSessions[i].Timestamp.After(allSessions[j].Timestamp)
-	})
+	return allSessions, nil
+}
 
-	// Apply limit
-	if limit > 0 && len(allSessions) > limit {
-		allSessions = allSessions[:limit]
+func (o *OpencodeAdapter) databasePath() string {
+	return filepath.Join(o.homeDir, ".local", "share", "opencode", "opencode.db")
+}
+
+func (o *OpencodeAdapter) openDatabase() (*sql.DB, error) {
+	databasePath := o.databasePath()
+	if _, err := os.Stat(databasePath); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to inspect opencode database: %w", err)
+	}
+	uri := (&url.URL{Scheme: "file", Path: databasePath, RawQuery: "mode=ro"}).String()
+	db, err := sql.Open("sqlite", uri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open opencode database: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to open opencode database: %w", err)
+	}
+	return db, nil
+}
+
+func (o *OpencodeAdapter) listDatabaseSessions(projectPath string) ([]Session, error) {
+	db, err := o.openDatabase()
+	if err != nil || db == nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	query := `
+		SELECT s.id, s.directory, s.title, s.time_created, COALESCE(p.worktree, '')
+		FROM session s
+		LEFT JOIN project p ON p.id = s.project_id`
+	var args []interface{}
+	if projectPath != "" {
+		absolutePath, err := filepath.Abs(projectPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path: %w", err)
+		}
+		query += " WHERE s.directory = ? OR p.worktree = ?"
+		args = append(args, absolutePath, absolutePath)
 	}
 
-	return allSessions, nil
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []Session
+	for rows.Next() {
+		var id, directory, title, worktree string
+		var created int64
+		if err := rows.Scan(&id, &directory, &title, &created, &worktree); err != nil {
+			return nil, fmt.Errorf("failed to read opencode session: %w", err)
+		}
+		firstMessage, userCount, err := databaseFirstUserMessageAndCount(db, id)
+		if err != nil {
+			return nil, err
+		}
+		if directory == "" {
+			directory = worktree
+		}
+		sessions = append(sessions, Session{
+			ID:               id,
+			Source:           "opencode",
+			ProjectPath:      directory,
+			FirstMessage:     extractFirstLine(firstMessage),
+			Summary:          title,
+			Timestamp:        time.UnixMilli(created),
+			FilePath:         o.databasePath(),
+			UserMessageCount: userCount,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to query opencode sessions: %w", err)
+	}
+	return sessions, nil
+}
+
+func databaseFirstUserMessageAndCount(db *sql.DB, sessionID string) (string, int, error) {
+	var count int
+	if err := db.QueryRow(`
+		SELECT COUNT(*) FROM message
+		WHERE session_id = ? AND json_extract(data, '$.role') = 'user'`, sessionID).Scan(&count); err != nil {
+		return "", 0, fmt.Errorf("failed to count opencode messages: %w", err)
+	}
+
+	var first sql.NullString
+	err := db.QueryRow(`
+		SELECT json_extract(p.data, '$.text')
+		FROM message m
+		JOIN part p ON p.message_id = m.id
+		WHERE m.session_id = ?
+		  AND json_extract(m.data, '$.role') = 'user'
+		  AND json_extract(p.data, '$.type') = 'text'
+		ORDER BY m.time_created, m.id, p.time_created, p.id
+		LIMIT 1`, sessionID).Scan(&first)
+	if err != nil && err != sql.ErrNoRows {
+		return "", 0, fmt.Errorf("failed to read opencode message: %w", err)
+	}
+	return first.String, count, nil
 }
 
 // findProjectIDByPath finds a project ID by matching the worktree path
@@ -311,16 +445,7 @@ func (o *OpencodeAdapter) extractFirstLine(text string) string {
 
 // GetSession retrieves the full content of an opencode session with pagination
 func (o *OpencodeAdapter) GetSession(sessionID string, page, pageSize int) ([]Message, error) {
-	storageDir := filepath.Join(o.homeDir, ".local", "share", "opencode", "storage")
-	messageDir := filepath.Join(storageDir, "message", sessionID)
-
-	// Check if message directory exists
-	if _, err := os.Stat(messageDir); os.IsNotExist(err) {
-		return nil, fmt.Errorf("session not found: %s", sessionID)
-	}
-
-	// Read all messages
-	messages, err := o.readAllMessages(messageDir)
+	messages, err := o.readSessionMessages(sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -337,6 +462,147 @@ func (o *OpencodeAdapter) GetSession(sessionID string, page, pageSize int) ([]Me
 	}
 
 	return messages[start:end], nil
+}
+
+func (o *OpencodeAdapter) readSessionMessages(sessionID string) ([]Message, error) {
+	if db, err := o.openDatabase(); err != nil {
+		return nil, err
+	} else if db != nil {
+		messages, found, err := readDatabaseMessages(db, sessionID)
+		db.Close()
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return messages, nil
+		}
+	}
+	return o.readLegacySessionMessages(sessionID)
+}
+
+func (o *OpencodeAdapter) readLegacySessionMessages(sessionID string) ([]Message, error) {
+	messageDir := filepath.Join(o.homeDir, ".local", "share", "opencode", "storage", "message", sessionID)
+	if _, err := os.Stat(messageDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("session not found: %s", sessionID)
+	}
+	return o.readAllMessages(messageDir)
+}
+
+func readDatabaseMessages(db *sql.DB, sessionID string) ([]Message, bool, error) {
+	var exists int
+	if err := db.QueryRow("SELECT COUNT(*) FROM session WHERE id = ?", sessionID).Scan(&exists); err != nil {
+		return nil, false, fmt.Errorf("failed to find opencode session: %w", err)
+	}
+	if exists == 0 {
+		return nil, false, nil
+	}
+
+	rows, err := db.Query(`
+		SELECT id, time_created, data
+		FROM message
+		WHERE session_id = ?
+		ORDER BY time_created, id`, sessionID)
+	if err != nil {
+		return nil, true, fmt.Errorf("failed to query opencode messages: %w", err)
+	}
+	defer rows.Close()
+
+	var messages []Message
+	for rows.Next() {
+		var id, rawData string
+		var created int64
+		if err := rows.Scan(&id, &created, &rawData); err != nil {
+			return nil, true, fmt.Errorf("failed to read opencode message: %w", err)
+		}
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(rawData), &data); err != nil {
+			continue
+		}
+
+		message := Message{
+			Role:      stringValue(data["role"]),
+			Timestamp: time.UnixMilli(created),
+			Metadata:  make(map[string]interface{}),
+		}
+		metadataKeys := map[string]string{
+			"modelID":    "model",
+			"providerID": "provider",
+			"mode":       "mode",
+			"agent":      "agent",
+			"cost":       "cost",
+			"tokens":     "tokens",
+		}
+		for source, target := range metadataKeys {
+			if value, ok := data[source]; ok {
+				message.Metadata[target] = value
+			}
+		}
+
+		partRows, err := db.Query(`
+			SELECT data FROM part
+			WHERE message_id = ?
+			ORDER BY time_created, id`, id)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to query opencode message parts: %w", err)
+		}
+		var textParts []string
+		var nonTextParts []interface{}
+		for partRows.Next() {
+			var rawPart string
+			if err := partRows.Scan(&rawPart); err != nil {
+				partRows.Close()
+				return nil, true, fmt.Errorf("failed to read opencode message part: %w", err)
+			}
+			var part map[string]interface{}
+			if json.Unmarshal([]byte(rawPart), &part) != nil {
+				continue
+			}
+			if part["type"] == "text" {
+				if text := stringValue(part["text"]); text != "" {
+					textParts = append(textParts, text)
+				}
+			} else {
+				nonTextParts = append(nonTextParts, part)
+			}
+		}
+		if err := partRows.Err(); err != nil {
+			partRows.Close()
+			return nil, true, fmt.Errorf("failed to read opencode message parts: %w", err)
+		}
+		partRows.Close()
+		message.Content = strings.Join(textParts, "\n")
+		if message.Content == "" {
+			message.Content = contentValue(data["content"])
+		}
+		if len(nonTextParts) > 0 {
+			message.Metadata["parts"] = nonTextParts
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, true, fmt.Errorf("failed to query opencode messages: %w", err)
+	}
+	return messages, true, nil
+}
+
+func stringValue(value interface{}) string {
+	text, _ := value.(string)
+	return text
+}
+
+func contentValue(value interface{}) string {
+	switch content := value.(type) {
+	case string:
+		return content
+	case nil:
+		return ""
+	default:
+		encoded, err := json.Marshal(content)
+		if err != nil {
+			return ""
+		}
+		return string(encoded)
+	}
 }
 
 // readAllMessages reads all messages from a session directory
@@ -404,6 +670,13 @@ func (o *OpencodeAdapter) SearchSessions(projectPath, query string, limit int) (
 
 	query = strings.ToLower(query)
 	var matches []Session
+	db, err := o.openDatabase()
+	if err != nil {
+		return nil, err
+	}
+	if db != nil {
+		defer db.Close()
+	}
 
 	// Search through each session
 	for _, session := range sessions {
@@ -414,10 +687,14 @@ func (o *OpencodeAdapter) SearchSessions(projectPath, query string, limit int) (
 			continue
 		}
 
-		// Search through full session content
-		storageDir := filepath.Join(o.homeDir, ".local", "share", "opencode", "storage")
-		messageDir := filepath.Join(storageDir, "message", session.ID)
-		messages, err := o.readAllMessages(messageDir)
+		var messages []Message
+		foundInDatabase := false
+		if db != nil {
+			messages, foundInDatabase, err = readDatabaseMessages(db, session.ID)
+		}
+		if err == nil && !foundInDatabase {
+			messages, err = o.readLegacySessionMessages(session.ID)
+		}
 		if err != nil {
 			continue
 		}

--- a/adapters/opencode_test.go
+++ b/adapters/opencode_test.go
@@ -1,0 +1,68 @@
+package adapters
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpencodeAdapterReadsSQLiteSessions(t *testing.T) {
+	home := t.TempDir()
+	dataDir := filepath.Join(home, ".local", "share", "opencode")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	databasePath := filepath.Join(dataDir, "opencode.db")
+	db, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	schema := []string{
+		`CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL)`,
+		`CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, directory TEXT NOT NULL, title TEXT NOT NULL, time_created INTEGER NOT NULL)`,
+		`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL)`,
+		`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT NOT NULL, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, data TEXT NOT NULL)`,
+		`INSERT INTO project VALUES ('project-1', '/worktree')`,
+		`INSERT INTO session VALUES ('session-1', 'project-1', '/worktree', 'SQLite session', 1786442400000)`,
+		`INSERT INTO message VALUES ('message-1', 'session-1', 1786442401000, '{"role":"user"}')`,
+		`INSERT INTO part VALUES ('part-1', 'message-1', 'session-1', 1786442401000, '{"type":"text","text":"Current database prompt"}')`,
+		`INSERT INTO message VALUES ('message-2', 'session-1', 1786442402000, '{"role":"assistant","modelID":"test-model"}')`,
+		`INSERT INTO part VALUES ('part-2', 'message-2', 'session-1', 1786442402000, '{"type":"text","text":"Current database answer"}')`,
+	}
+	for _, statement := range schema {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatalf("failed SQL %q: %v", statement, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := &OpencodeAdapter{homeDir: home}
+	sessions, err := adapter.ListSessions("/worktree", 0)
+	if err != nil {
+		t.Fatalf("ListSessions returned error: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "session-1" || sessions[0].FirstMessage != "Current database prompt" {
+		t.Fatalf("unexpected sessions: %+v", sessions)
+	}
+
+	messages, err := adapter.GetSession("session-1", 0, 10)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if len(messages) != 2 || messages[1].Content != "Current database answer" || messages[1].Metadata["model"] != "test-model" {
+		t.Fatalf("unexpected messages: %+v", messages)
+	}
+
+	matches, err := adapter.SearchSessions("/worktree", "database answer", 0)
+	if err != nil {
+		t.Fatalf("SearchSessions returned error: %v", err)
+	}
+	if len(matches) != 1 || matches[0].ID != "session-1" {
+		t.Fatalf("unexpected search results: %+v", matches)
+	}
+}

--- a/cmd/ai-sessions/cli.go
+++ b/cmd/ai-sessions/cli.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/manifoldco/promptui"
 	"github.com/yoavf/ai-sessions-mcp/adapters"
 	"golang.org/x/term"
@@ -444,19 +445,38 @@ func formatTableHeader() string {
 	return fmt.Sprintf("  %-12s  %-12s  %5s  %-28s  %s", "TIME", "AGENT", "#USER", "PROJECT", "MESSAGE")
 }
 
-// selectSessionInteractively displays an interactive list of recent sessions
-// and returns the file path of the selected session
-func selectSessionInteractively() (string, error) {
+type sessionProgress interface {
+	Start()
+	Stop()
+}
+
+func newSessionLoadingProgress() sessionProgress {
+	return spinner.New(
+		spinner.CharSets[14],
+		100*time.Millisecond,
+		spinner.WithColor("cyan"),
+		spinner.WithSuffix("  Loading sessions..."),
+		spinner.WithWriterFile(os.Stderr),
+	)
+}
+
+func loadSessionsWithProgress(progress sessionProgress, load func() ([]adapters.Session, error)) ([]adapters.Session, error) {
+	progress.Start()
+	defer progress.Stop()
+	return load()
+}
+
+func loadRecentSessions() ([]adapters.Session, error) {
 	// Initialize Claude adapter
 	claudeAdapter, err := adapters.NewClaudeAdapter()
 	if err != nil {
-		return "", fmt.Errorf("failed to initialize Claude adapter: %w", err)
+		return nil, fmt.Errorf("failed to initialize Claude adapter: %w", err)
 	}
 
 	// List recent sessions (fetch more to account for empty sessions being filtered out)
 	sessions, err := claudeAdapter.ListSessions("", 200)
 	if err != nil {
-		return "", fmt.Errorf("failed to list sessions: %w", err)
+		return nil, fmt.Errorf("failed to list sessions: %w", err)
 	}
 
 	// Try to load Codex sessions (ignore errors to keep Claude flow working)
@@ -485,6 +505,17 @@ func selectSessionInteractively() (string, error) {
 		if copilotSessions, listErr := copilotAdapter.ListSessions("", 200); listErr == nil {
 			sessions = append(sessions, copilotSessions...)
 		}
+	}
+
+	return sessions, nil
+}
+
+// selectSessionInteractively displays an interactive list of recent sessions
+// and returns the file path of the selected session
+func selectSessionInteractively() (string, error) {
+	sessions, err := loadSessionsWithProgress(newSessionLoadingProgress(), loadRecentSessions)
+	if err != nil {
+		return "", err
 	}
 
 	if len(sessions) == 0 {

--- a/cmd/ai-sessions/cli_test.go
+++ b/cmd/ai-sessions/cli_test.go
@@ -168,6 +168,55 @@ func TestFormatTableHeader(t *testing.T) {
 	}
 }
 
+type recordingSessionProgress struct {
+	events *[]string
+}
+
+func (p *recordingSessionProgress) Start() {
+	*p.events = append(*p.events, "start")
+}
+
+func (p *recordingSessionProgress) Stop() {
+	*p.events = append(*p.events, "stop")
+}
+
+func TestLoadSessionsWithProgressStopsAfterSuccess(t *testing.T) {
+	var events []string
+	progress := &recordingSessionProgress{events: &events}
+	want := []adapters.Session{{ID: "session-1"}}
+
+	got, err := loadSessionsWithProgress(progress, func() ([]adapters.Session, error) {
+		events = append(events, "load")
+		return want, nil
+	})
+	if err != nil {
+		t.Fatalf("loadSessionsWithProgress returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != want[0].ID {
+		t.Fatalf("unexpected sessions: %+v", got)
+	}
+	if strings.Join(events, ",") != "start,load,stop" {
+		t.Fatalf("unexpected progress events: %v", events)
+	}
+}
+
+func TestLoadSessionsWithProgressStopsAfterError(t *testing.T) {
+	var events []string
+	progress := &recordingSessionProgress{events: &events}
+	wantErr := fmt.Errorf("discovery failed")
+
+	_, err := loadSessionsWithProgress(progress, func() ([]adapters.Session, error) {
+		events = append(events, "load")
+		return nil, wantErr
+	})
+	if err != wantErr {
+		t.Fatalf("loadSessionsWithProgress error=%v want %v", err, wantErr)
+	}
+	if strings.Join(events, ",") != "start,load,stop" {
+		t.Fatalf("unexpected progress events: %v", events)
+	}
+}
+
 func TestGetAPIURL(t *testing.T) {
 	if got := getAPIURL(""); got != defaultAPIURL {
 		t.Fatalf("getAPIURL empty returned %q want %q", got, defaultAPIURL)


### PR DESCRIPTION
## Summary
- read current Copilot session-state/<id>/events.jsonl logs and project context while retaining flat JSONL support
- read current OpenCode SQLite sessions, messages, and parts while retaining the legacy JSON storage tree
- read current Gemini append-only JSONL recordings, including metadata updates and rewinds, while retaining legacy JSON support
- omit provider-injected XML context envelopes from Codex previews and transcripts while preserving any real prompt in the same record
- show an interactive loading spinner while the upload session picker discovers sessions
- document the current storage locations and add regression coverage for each format

## Validation
- go test ./...
- go test -race ./...
- go vet ./...
- CGO_ENABLED=0 go build ./cmd/ai-sessions
- live local-store audit: Copilot 4 sessions, OpenCode 457 combined current/legacy sessions, Gemini 2 sessions for this project
- live Codex preview audit: 165 recent sessions with no recognized provider-context preview remaining
- interactive PTY smoke test: loading spinner clears before the session picker renders