### PR TITLE
Correct release setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An MCP server that makes sessions from Claude Code, OpenAI Codex, Gemini CLI, op
 
 ## What It Does
 
-Allow AI agents to search, list, and read your previous local coding sessions from multiple CLI coding agents. Useful for:
+Allows AI agents to search, list, and read your previous local coding sessions from multiple CLI coding agents. Useful for:
 
 - Finding past solutions to similar problems
 - Reviewing what you worked on recently
@@ -24,7 +24,7 @@ Allow AI agents to search, list, and read your previous local coding sessions fr
 
 ### Quick Install
 
-**macOS, Linux, and Windows (Git Bash/WSL):**
+**macOS (Intel and Apple Silicon), Linux (amd64 and arm64, including WSL), and Windows amd64 (Git Bash):**
 
 ```bash
 curl -fsSL https://aisessions.dev/install.sh | bash
@@ -35,7 +35,7 @@ This installs the binary to `~/.aisessions/bin`. Follow the instructions to add 
 **Custom installation directory:**
 
 ```bash
-INSTALL_DIR=/custom/path curl -fsSL https://aisessions.dev/install.sh | bash
+curl -fsSL https://aisessions.dev/install.sh | INSTALL_DIR=/custom/path bash
 ```
 
 ### Manual Download
@@ -61,6 +61,7 @@ claude mcp add --scope user --transport stdio ai-sessions -- ~/.aisessions/bin/a
 ```
 
 Or if using a custom install location:
+
 ```bash
 claude mcp add --scope user --transport stdio ai-sessions -- /path/to/aisessions
 ```
@@ -89,6 +90,7 @@ Replace `YOUR_USERNAME` with your actual username, or use your custom install pa
 #### Claude Desktop
 
 Add to the config file opened from **Settings** → **Developer** → **Edit Config**:
+
 ```json
 {
   "mcpServers": {
@@ -105,7 +107,7 @@ Restart Claude Desktop, then open **Developer** settings or **+** → **Connecto
 
 ## CLI Upload
 
-The `ai-sessions` binary includes a CLI tool for uploading Claude Code transcripts to [aisessions.dev](https://aisessions.dev) for sharing.
+The `aisessions` binary includes a CLI tool for uploading supported local agent transcripts to [aisessions.dev](https://aisessions.dev) for sharing.
 
 ### Authentication
 
@@ -123,7 +125,7 @@ Opens your browser to generate a CLI token. The token is saved locally in `~/.ai
 aisessions upload
 ```
 
-Displays a searchable list of your recent Claude Code sessions. Use arrow keys to navigate and select a session to upload.
+Displays a searchable list of recent upload-compatible sessions from Claude Code, Codex, Gemini CLI, Mistral Vibe, and GitHub Copilot CLI. Use arrow keys to navigate and select a session to upload. opencode sessions remain available through the MCP server but are omitted from the upload picker because its current store is a shared SQLite database rather than one transcript file per session.
 
 **Direct mode** (with file path):
 
@@ -135,6 +137,7 @@ aisessions upload /path/to/session.jsonl --title "Custom Title"
 ### Options
 
 - `--title <title>` - Set a custom title for the uploaded transcript
+- `--url <url>` - Override the API URL (`https://aisessions.dev` or a local development server)
 
 ## MCP Usage
 
@@ -156,17 +159,20 @@ The server reads session files stored locally by various CLI coding agents:
 - **Mistral Vibe**: `~/.vibe/logs/session/`
 - **GitHub Copilot CLI**: `~/.copilot/session-state/[SESSION_ID]/events.jsonl` (plus legacy flat JSONL files)
 
-When you ask your AI agent to list or search sessions, it automatically uses these agents to access your session history.
+When you ask your AI agent to list or search sessions, the server reads these local stores through source-specific adapters; it does not launch the agent CLIs.
 
 ## Available Tools
 
 ### `list_available_sources`
-Shows which AI CLI coding agents have sessions on your system.
+
+Shows which AI CLI source adapters are available from the running server.
 
 ### `list_sessions`
+
 Lists recent sessions from all projects (newest first).
 
 **Arguments**:
+
 - `source` (optional): Filter by `claude`, `gemini`, `codex`, `opencode`, `mistral`, or `copilot`
 - `project_path` (optional): Filter by specific project directory
 - `limit` (optional): Max results (default: 10)
@@ -174,9 +180,11 @@ Lists recent sessions from all projects (newest first).
 **Example**: `{"source": "claude", "limit": 20}`
 
 ### `search_sessions`
+
 Searches session content using BM25 ranking. Returns results sorted by relevance score with contextual snippets.
 
 **Arguments**:
+
 - `query` (required): Search term (supports multiple keywords)
 - `source` (optional): Filter by source
 - `project_path` (optional): Filter by project
@@ -185,14 +193,17 @@ Searches session content using BM25 ranking. Returns results sorted by relevance
 **Example**: `{"query": "authentication bug"}`
 
 **Returns**: Each match includes:
+
 - `session`: Session metadata (ID, source, project, timestamp)
 - `score`: Relevance score (higher = more relevant)
 - `snippet`: Contextual excerpt (~300 chars) showing where the match occurred
 
 ### `get_session`
+
 Retrieves full session content with pagination.
 
 **Arguments**:
+
 - `session_id` (required): Session ID from list results
 - `source` (required): Which coding agent created it
 - `page` (optional): Page number (default: 0)
@@ -203,7 +214,7 @@ Retrieves full session content with pagination.
 To keep formatting consistent and catch regressions early:
 
 - Install [pre-commit](https://pre-commit.com/) and run `pre-commit install` to enable hooks (`gofmt`, `go vet`, `go test`).
-- All pushes and pull requests run the GitHub Actions workflow (`.github/workflows/build.yml`), which checks formatting, runs `go vet`, builds the binary, and executes `go test -cover ./...`.
+- Pushes to `main` and pull requests targeting `main` run the GitHub Actions workflow (`.github/workflows/build.yml`), which checks formatting, runs `go vet`, builds the binary, and executes `go test -cover ./...`.
 
 ## License
 


### PR DESCRIPTION
## Summary

- fix the custom `INSTALL_DIR` pipeline so the variable reaches the installer
- clarify the supported OS and architecture matrix
- update upload documentation for the current binary name and supported session sources
- document the `--url` option and the actual `list_available_sources` behavior
- align the local-store and CI wording with the implementation

## Why

A pre-release audit found that the custom installation example applied `INSTALL_DIR` to `curl` instead of `bash`, and several descriptions still reflected the older Claude-only upload picker. These corrections make the README match the merged v1.7 behavior before tagging.

## Validation

- `go test ./...`
- repository pre-commit hooks (`go vet ./...`, `go test ./...`)
- fresh-checkout build using the documented command
- shell assertion that `INSTALL_DIR` reaches the installer process
- live HTTP checks for every README link
- CLI help and release asset matrix compared with the documented options and platforms